### PR TITLE
Fix regex for HathiTrust links.

### DIFF
--- a/hathitrustPDF.py
+++ b/hathitrustPDF.py
@@ -154,7 +154,7 @@ def main():
 def download_link(args, link, output):
     start_time = time.time()
     if "babel.hathitrust.org" in link:
-        id_book = re.findall(r'id=(\w*\.\d*)|$', link)[0]
+        id_book = re.findall(r'id=(\w*\.\w*)|$', link)[0]
     elif "hdl.handle.net" in link:
         link.rstrip('/')
         id_book = re.findall(r'.+/(.+)', link)[0]


### PR DESCRIPTION
Fixed regex for HathiTrust links as sometimes the document id is of the format 'abcd.a9999999'. Original regex was only looking for digits in the second part of the id and would not get the correct document.